### PR TITLE
Make adding primitives easier

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -1,0 +1,15 @@
+# Missing compiler primitives
+
+If you ever run into a Malfunction error like the following,
+```
+Fatal error: exception Failure("unimplemented primitive %primitive")
+```
+you can fix it as follows:
+
+1. find `translprim.ml` somewhere in `opam`
+2. search for your `%primitive` there and see how it's defined
+3. add the definition into the match expression [starting around line 318 in the source](https://github.com/stedolan/malfunction/blob/master/src/malfunction_compiler.ml#L318)
+4. `duna build` to check if it builds
+5. commit
+6. `opam reinstall malfunction` to reinstall Malfunction with your patch
+7. send a pull request! :)

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6,7 +6,7 @@ Fatal error: exception Failure("unimplemented primitive %primitive")
 ```
 you can fix it as follows:
 
-1. find `translprim.ml` somewhere in `opam`
+1. find `translprim.ml` somewhere in `~/.opam`
 2. search for your `%primitive` there and see how it's defined
 3. add the definition into the match expression [starting around line 318 in the source](https://github.com/stedolan/malfunction/blob/master/src/malfunction_compiler.ml#L318)
 4. `duna build` to check if it builds

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -312,9 +312,7 @@ let lookup env v =
   match descr.val_kind with
   | Val_reg -> Glob_val (transl_value_path (Location.none) env path)
   | Val_prim(p) -> (
-     (* if you need more primitives, find translprim.ml somewhere in ~/.opam
-      * and search for your %primitive to see how it's defined
-      *)
+     (* see docs/primitives.md on how to add more primitives *)
      match p.prim_name with
        | "%equal" ->
           Glob_prim (Primitive.simple ~name:"caml_equal" ~arity:2 ~alloc:true)


### PR DESCRIPTION
This patch:
* adds support for `Lambda.primitive`s
* adds a couple of new string primitives as an example
* adds a (very brief) doc

Addresses #21.