### PR TITLE
Add all the primitives from translprim.ml

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -1,0 +1,15 @@
+# Missing compiler primitives
+
+If you ever run into a Malfunction error like the following,
+```
+Fatal error: exception Failure("unimplemented primitive %primitive")
+```
+you can fix it as follows:
+
+1. find `translprim.ml` somewhere in `opam`
+2. search for your `%primitive` there and see how it's defined
+3. add the definition into the match expression [starting around line 318 in the source](https://github.com/stedolan/malfunction/blob/master/src/malfunction_compiler.ml#L318)
+4. `duna build` to check if it builds
+5. commit
+6. `opam reinstall malfunction` to reinstall Malfunction with your patch
+7. send a pull request! :)

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6,7 +6,7 @@ Fatal error: exception Failure("unimplemented primitive %primitive")
 ```
 you can fix it as follows:
 
-1. find `translprim.ml` somewhere in `opam`
+1. find `translprim.ml` somewhere in `~/.opam`
 2. search for your `%primitive` there and see how it's defined
 3. add the definition into the match expression [starting around line 318 in the source](https://github.com/stedolan/malfunction/blob/master/src/malfunction_compiler.ml#L318)
 4. `duna build` to check if it builds

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -312,9 +312,7 @@ let lookup env v =
   match descr.val_kind with
   | Val_reg -> Glob_val (transl_value_path (Location.none) env path)
   | Val_prim(p) -> (
-     (* if you need more primitives, find translprim.ml somewhere in ~/.opam
-      * and search for your %primitive to see how it's defined
-      *)
+     (* see docs/primitives.md on how to add more primitives *)
      match p.prim_name with
        | "%equal" ->
           Glob_prim (Primitive.simple ~name:"caml_equal" ~arity:2 ~alloc:true)

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -290,6 +290,9 @@ type global_value =
   | Glob_prim of Primitive.description
   | Glob_lam of Lambda.primitive * int
 
+let gen_array_kind =
+  if Config.flat_float_array then Pgenarray else Paddrarray
+
 let lookup env v =
   let open Types in
   let open Primitive in
@@ -324,6 +327,10 @@ let lookup env v =
           Glob_lam (Pstringrefs, 2);
        | "%string_unsafe_get" ->
           Glob_lam (Pstringrefu, 2);
+       | "%array_unsafe_get" ->
+          Glob_lam ((Parrayrefu gen_array_kind), 2);
+       | "%array_unsafe_set" ->
+          Glob_lam ((Parraysetu gen_array_kind), 3);
        | s when s.[0] = '%' ->
           failwith ("unimplemented primitive " ^ p.prim_name);
        | _ -> Glob_prim p

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -331,6 +331,8 @@ let lookup env v =
           Glob_lam ((Parrayrefu gen_array_kind), 2);
        | "%array_unsafe_set" ->
           Glob_lam ((Parraysetu gen_array_kind), 3);
+       | "%field0" -> Glob_lam ((Pfield 0), 1);
+       | "%setfield0" -> Glob_lam ((Psetfield(0, Pointer, Assignment)), 2);
        | s when s.[0] = '%' ->
           failwith ("unimplemented primitive " ^ p.prim_name);
        | _ -> Glob_prim p


### PR DESCRIPTION
This patch adds all primitives from `translprim.ml` that are expressible in the current implementation.

This may be controversial because I don't know how stable the interface of primitives is between OCaml releases. I can imagine that you intentionally keep the primitives minimal to reduce breakage when upgrading. That's why I'm sending it as a separate pull request, an alternative to #22.

This addresses #21, too. :)