### PR TITLE
Move to opam 2.0

### DIFF
--- a/malfunction.opam
+++ b/malfunction.opam
@@ -1,20 +1,25 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "stephen.dolan@cl.cam.ac.uk"
 authors: ["Stephen Dolan"]
 homepage: "https://github.com/stedolan/malfunction"
 bug-reports: "https://github.com/stedolan/malfunction/issues"
-dev-repo: "https://github.com/stedolan/malfunction.git"
-license: "LGPL"
-build:
-[[ "jbuilder" "build" "--only-packages" "%{name}%" "--root" "." "-j" jobs "@install" ]]
-build-test:
-[[ "jbuilder" "build" "--only-packages" "%{name}%" "--root" "." "-j" jobs "@runtest" ]]
-available: [ ocaml-version >= "4.04" ]
+dev-repo: "git+https://github.com/stedolan/malfunction.git"
+license: "LGPL-2.0-or-later"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
 depends: [
+  "ocaml" {>= "4.04"}
   "ocamlfind"
-  "dune" {build}
+  "dune"
   "cppo" {build}
-  "omd" {test}
-  "craml" {test}
+  "omd" {with-test & < "2.0.0~"}
+  "craml" {with-test}
   "zarith"
 ]
+synopsis: "Compiler back-end for functional languages, based on OCaml"
+description: """
+Malfunction is a high-performance, low-level untyped program
+representation, designed as a target for compilers of functional
+programming languages."""


### PR DESCRIPTION
I copied the contents of the opam file in opam-repository, removed the upper bound on OCaml version and put an upper bound on the `omd` package (it didn't compile on version 2.0.0).

Here is a relevant PR to opam-repository putting an upper bound on `omd`: https://github.com/ocaml/opam-repository/pull/18440.