### PR TITLE
VERY WIP - update for ocaml 5.0

### DIFF
--- a/examples/helloworld.mlf
+++ b/examples/helloworld.mlf
@@ -1,3 +1,6 @@
 (module
-  (_ (apply (global $Stdlib $print_string) "Hello, world!\n"))
+  ($prt (global $Stdlib $print_int))
+  ($p2 
+    (lambda ($arg1) (lambda ($arg2) (+ $arg1 $arg2))))
+  (_ (apply $prt (apply $p2 5 10)))
   (export))

--- a/src/malfunction_compat.cppo.ml
+++ b/src/malfunction_compat.cppo.ml
@@ -39,26 +39,21 @@ let lfunction params body =
 #if OCAML_VERSION >= (4, 08, 0)
   let params = List.map (fun x -> x, Pgenval) params in
 #endif
-  Lfunction {
-     kind = Curried;
-     params;
-     body;
-     loc = loc_none;
-     attr = {
+  lfunction 
+    ~kind:Curried
+     ~params
+     ~body
+     ~loc:loc_none
+     ~attr:{
        inline = Default_inline;
        specialise = Default_specialise;
        is_a_functor = false;
-#if OCAML_VERSION >= (4, 05, 0)
+       tmc_candidate = false;
+       poll = Default_poll;
        stub = false;
-#endif
-#if OCAML_VERSION >= (4, 08, 0)
        local = Default_local;
-#endif
-     };
-#if OCAML_VERSION >= (4, 08, 0)
-     return = Pgenval;
-#endif
-   }
+     }
+     ~return:Pgenval
 
 let lapply fn args =
   Lapply {
@@ -241,7 +236,13 @@ let compile_implementation
     if Config.flambda then Flambda_middle_end.lambda_to_clambda
     else Closure_middle_end.lambda_to_clambda
   in
+  let _ = filename in 
   Asmgen.compile_implementation
-    ?toplevel:None ~backend ~filename ~prefixname ~middle_end ~ppf_dump:ppf
+    ?toplevel:None 
+    ~backend 
+   (* ~filename *)
+    ~prefixname 
+    ~middle_end 
+    ~ppf_dump:ppf
     program
 #endif

--- a/test/test.ml
+++ b/test/test.ml
@@ -157,18 +157,18 @@ let load_testcases_markdown filename =
   let dummy_loc =
     let l = Lexing.{pos_fname = filename; pos_lnum = 0; pos_cnum = 0; pos_bol = 0} in
     l,l in
-  let open Omd_representation in
+  let open Omd in
   let testcases = ref [] in
-  let _ = Omd.of_string contents |> visit @@ function
-    | Code_block (("test" | " test"), s) ->
+  let _ = Omd.of_string contents |> List.iter @@ function
+    | Code_block (_, ("test" | " test"), s) ->
        let open Str in
        let (test, expect) = match split (regexp "\n=>") s with
          | [t; e] -> (parse_string t, parse_string e)
          | _ -> failwith @@ "Cannot parse testcase " ^ s in
        testcases := (`Test, dummy_loc, test, expect) :: !testcases;
-       None
-    | _ ->
-       None in
+       ()
+    | _ -> ()
+  in
   List.rev !testcases
 
 let run_file parser filename =


### PR DESCRIPTION
This pull-request contains the diff necessary to get malfunction to compile (and pass all tests) in an ocaml 5.0 opam switch

This patch is bad for the following reasons:
- it becomes less portable by removing some ifdefs
- functions and types necessary for the switch functor invocation were implemented blindly
- values for new `Pfield` constructor args were basically picked at random

Please don't merge this, but maybe it's an ok starting-point for a real attempt