### PR TITLE
Support -package -for-pack and -shared options

### DIFF
--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -626,7 +626,6 @@ and bindings_to_lambda env bindings body =
      Lletrec (List.map (fun (n, e) -> (n, to_lambda env e)) bs, rest))
     bindings body
 
-
 let setup_options options =
   Clflags.native_code := true;
   Clflags.flambda_invariant_checks := true;
@@ -638,7 +637,6 @@ let setup_options options =
   Clflags.inlining_report := false;
   Clflags.dlcode := true;
   Clflags.shared := false;
-
   Clflags.(
     default_simplify_rounds := 2;
     use_inlining_arguments_set o2_arguments;
@@ -660,7 +658,12 @@ let setup_options options =
      Clflags.inlining_report := true
       *)
   | `Shared ->
-     Clflags.shared := true);
+     Clflags.shared := true
+  | `Package s -> 
+     let packages = String.split_on_char ',' s in
+     let dirs = List.map Findlib.package_directory packages in
+     Clflags.include_dirs := dirs @ !Clflags.include_dirs
+  | `ForPack s -> Clflags.for_package := Some s);
 
   Compenv.(readenv Format.std_formatter (Before_compile "malfunction"));
   compmisc_init_path ()
@@ -754,7 +757,7 @@ let delete_temps { objfile; cmxfile; cmifile } =
   match cmifile with Some f -> Misc.remove_file f | None -> ()
 
 
-type options = [`Verbose | `Shared] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string] list
 
 
 let lambda_to_cmx ?(options=[]) ~filename ~prefixname ~module_name ~module_id lmod =

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -6,7 +6,7 @@ type outfiles = {
 }
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string`] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -6,7 +6,7 @@ type outfiles = {
 }
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string`] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_main.ml
+++ b/src/malfunction_main.ml
@@ -6,8 +6,9 @@ let usage () =
     "Malfunction v0.1. Usage:\n"^
     "   malfunction compile [-v] [-o output] input.mlf\n" ^
     "     Compile input.mlf to an executable\n\n" ^
-    "   malfunction cmx [-v] input.mlf\n" ^
-    "     Compile input.mlf to input.cmx, for linking with ocamlopt\n\n" ^
+    "   malfunction cmx [-v] [-shared] [-package pack1,...,packn] [-for-pack s] input.mlf\n" ^
+    "     Compile input.mlf to input.cmx, for linking with ocamlopt.\n"^
+    "     Package \"zarith\" is always included.\n\n" ^
     "   malfunction eval\n" ^
     "     Run a REPL to evaluate expressions with the interpreter\n\n" ^
     "   malfunction fmt\n" ^
@@ -64,6 +65,9 @@ let parse_args args =
   let rec parse_opts mode = function
     | "-v" :: rest -> opts := `Verbose :: !opts; parse_opts mode rest
     | "-o" :: o :: rest -> output := Some o; parse_opts mode rest
+    | "-shared" :: rest -> opts := `Shared :: !opts; parse_opts mode rest
+    | "-for-pack" :: o :: rest -> opts := `ForPack o :: !opts; parse_opts mode rest
+    | "-package" :: s :: rest -> opts := `Package s :: !opts; parse_opts mode rest
     | i :: rest ->
        (match !impl with None -> (impl := Some i; parse_opts mode rest) | _ -> usage ())
     | [] -> run mode !opts !impl !output in


### PR DESCRIPTION
This is useful in the coq-malfunction project to build a plugin in a separate namespace (our mlf is generated code). -package is necessary to resolve potential external references.