### PR TITLE
Fix out of bounds vector write in `malfunction_interpreter.ml`

### DIFF
--- a/src/malfunction_interpreter.ml
+++ b/src/malfunction_interpreter.ml
@@ -224,7 +224,7 @@ let rec interpret locals env : t -> value = function
             interpret locals env e with
      | Vec (ty', vals), Int (`Int, i), v when ty = ty' ->
         let i = Z.to_int i in
-        if 0 <= i && i <= Array.length vals then begin
+        if 0 <= i && i < Array.length vals then begin
           (match ty, v with
           |  `Array, _ -> ()
           | `Bytevec, Int (`Int, i) when 0 <= Z.to_int i && Z.to_int i < 256 -> ()


### PR DESCRIPTION
The condition `if 0 <= i && i <= Array.length vals then` for `Mvecset` lets the interpreter crash on `(let ($x (makevec 0 0)) (store $x 0 0))` with `Fatal error: exception Invalid_argument("index out of bounds")` rather than report `Undefined behaviour: index out of bounds: 0`.

The check is correct for `Mvecget`.

Discovered by @tabareau