### PR TITLE
Support for -package and -dontlink in linking of output files

### DIFF
--- a/malfunction.opam
+++ b/malfunction.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "0.5"
 maintainer: "stephen.dolan@cl.cam.ac.uk"
 authors: ["Stephen Dolan"]
 homepage: "https://github.com/stedolan/malfunction"

--- a/malfunction.opam
+++ b/malfunction.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "0.5"
 maintainer: "stephen.dolan@cl.cam.ac.uk"
 authors: ["Stephen Dolan"]
 homepage: "https://github.com/stedolan/malfunction"

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -632,11 +632,9 @@ let setup_options options =
   Clflags.inlining_report := false;
   Clflags.dlcode := true;
   Clflags.shared := false;
-  Clflags.(
-    default_simplify_rounds := 2;
-    use_inlining_arguments_set o2_arguments;
-    use_inlining_arguments_set ~round:0 o1_arguments);
+  Clflags.(default_simplify_rounds := 0);
   (* FIXME: should we use classic_arguments for non-flambda builds? *)
+
 
   (* Hack: disable the "no cmx" warning for zarith *)
   let _ = Warnings.parse_options false "-58" in
@@ -646,11 +644,11 @@ let setup_options options =
   | `Verbose ->
      Clflags.dump_lambda := true;
      Clflags.dump_cmm := true;
+     Clflags.keep_asm_file := true;
+     Clflags.inlining_report := true
      (*
        If anyone wants to keep these, there should probably be another option for where to put them.
        (rather than leaving stale temporary directories around)
-     Clflags.keep_asm_file := true;
-     Clflags.inlining_report := true
       *)
   | `Shared ->
      Clflags.shared := true
@@ -661,7 +659,13 @@ let setup_options options =
   | `ForPack s -> Clflags.for_package := Some s
   | `Dontlink _ -> ()
   | `Linkpkg -> ()
-  | `Thread -> ());
+  | `Thread -> ()
+  | `Optimize ->   Clflags.(
+    default_simplify_rounds := 2;
+    use_inlining_arguments_set o2_arguments;
+    use_inlining_arguments_set ~round:0 o1_arguments);
+   );
+  (* FIXME: should we use classic_arguments for non-flambda builds? *)
 
   Compenv.(readenv Format.std_formatter (Before_compile "malfunction"));
   compmisc_init_path ()
@@ -755,8 +759,7 @@ let delete_temps { objfile; cmxfile; cmifile } =
   match cmifile with Some f -> Misc.remove_file f | None -> ()
 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread] list
-
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize] list
 
 let lambda_to_cmx ?(options=[]) ~filename ~prefixname ~module_name ~module_id lmod =
   let ppf = Format.std_formatter in

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -6,7 +6,7 @@ type outfiles = {
 }
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg] list
 
 val compile_module :
   ?options:options ->
@@ -16,6 +16,6 @@ val compile_module :
 
 val compile_cmx : ?options:options -> string -> outfiles
 
-val link_executable : string -> outfiles -> int
+val link_executable : ?options:options -> string -> outfiles -> int
 
 val compile_and_load : ?options:options -> Malfunction.t -> Obj.t

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -6,7 +6,7 @@ type outfiles = {
 }
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -6,7 +6,7 @@ type outfiles = {
 }
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg] list
+type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_main.ml
+++ b/src/malfunction_main.ml
@@ -77,6 +77,7 @@ let parse_args args =
     | "-thread" :: rest -> 
         if mode = `Compile then (opts := `Thread :: !opts; parse_opts mode rest)
         else usage ()
+    | "-O2" :: rest -> opts := `Optimize :: !opts; parse_opts mode rest
     | i :: rest ->
        (match !impl with None -> (impl := Some i; parse_opts mode rest) | _ -> usage ())
     | [] -> run mode !opts !impl !output in

--- a/src/malfunction_main.ml
+++ b/src/malfunction_main.ml
@@ -4,9 +4,8 @@ open Malfunction
 let usage () =
   Printf.fprintf stderr "%s" @@
     "Malfunction v0.1. Usage:\n"^
-    "   malfunction compile [-v] [-linkpkg] [-dontlink pack1,...,packn] [-package pack1,...packn] [-o output] input.mlf\n" ^
+    "   malfunction compile [-v] [-thread] [-linkpkg] [-dontlink pack1,...,packn] [-package pack1,...packn] [-o output] input.mlf\n" ^
     "     Compile input.mlf to an executable using ocamlfind\n" ^
-    "     Package \"zarith\" is always included and linked.\n\n" ^
     "   malfunction cmx [-v] [-shared] [-package pack1,...,packn] [-for-pack s] input.mlf\n" ^
     "     Compile input.mlf to input.cmx, for linking with ocamlopt.\n"^
     "     Package \"zarith\" is always included.\n\n" ^
@@ -75,6 +74,9 @@ let parse_args args =
     | "-linkpkg" :: rest -> 
       if mode = `Compile then (opts := `Linkpkg :: !opts; parse_opts mode rest)
       else usage ()
+    | "-thread" :: rest -> 
+        if mode = `Compile then (opts := `Thread :: !opts; parse_opts mode rest)
+        else usage ()
     | i :: rest ->
        (match !impl with None -> (impl := Some i; parse_opts mode rest) | _ -> usage ())
     | [] -> run mode !opts !impl !output in


### PR DESCRIPTION
This adds a few options to drive the `ocamlfind` linking, especially useful in our implementation of the malfunction backend of the verified MetaCoq extraction (yforster/coq-malfunction#13).
I'm not sure why you added a `version: 0.5` in your commit, @yforster . Maybe we just remove it?
I think otherwise it is ready for review @stedolan 