### PR TITLE
Allow quotes in identifiers.

### DIFF
--- a/src/malfunction_sexp.mll
+++ b/src/malfunction_sexp.mll
@@ -37,7 +37,7 @@ let letter = ['a'-'z' 'A'-'Z' '_']
 let digit = ['0' - '9']
 
 let atom = (letter | digit | symbol)*
-let var = (['a'-'z' 'A'-'Z' '_' '0'-'9' '$'] | symbol)+
+let var = (['a'-'z' 'A'-'Z' '_' '0'-'9' '$' '\''] | symbol)+
 
 let string = '"' ([^ '\\' '"']* | ('\\' _))* '"'
 


### PR DESCRIPTION
The documentation states that the precise specification of identifier syntax is intentionally vague. Yet I believe that one should be able to call arbitrary OCaml code from malfunction. For this to be possible, this means that all OCaml identifiers need to be valid malfunction identifier. As per the OCaml syntax, this means we have to allow single quotes in malfunction.