### PR TITLE
Support the -I and -g flags

### DIFF
--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -652,6 +652,8 @@ let setup_options options =
       *)
   | `Shared ->
      Clflags.shared := true
+  | `Include dir ->
+     Clflags.include_dirs := dir :: !Clflags.include_dirs
   | `Package s -> 
      let packages = String.split_on_char ',' s in
      let dirs = List.map Findlib.package_directory packages in
@@ -759,7 +761,7 @@ let delete_temps outfiles =
   in
   List.iter Misc.remove_file temps
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
+type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
 
 let ensure_cmi ~module_name ~filename =
   let cmi = module_name ^ ".cmi" in

--- a/src/malfunction_compiler.ml
+++ b/src/malfunction_compiler.ml
@@ -661,6 +661,7 @@ let setup_options options =
   | `ForPack s -> Clflags.for_package := Some s
   | `Dontlink _ -> ()
   | `Linkpkg -> ()
+  | `Debug -> Clflags.debug := true
   | `Thread -> ()
   | `Optimize ->   Clflags.(
     default_simplify_rounds := 2;
@@ -761,7 +762,7 @@ let delete_temps outfiles =
   in
   List.iter Misc.remove_file temps
 
-type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
+type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Debug | `Thread | `Optimize | `Bytecode] list
 
 let ensure_cmi ~module_name ~filename =
   let cmi = module_name ^ ".cmi" in

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -2,7 +2,7 @@
 type outfiles
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
+type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_compiler.mli
+++ b/src/malfunction_compiler.mli
@@ -2,7 +2,7 @@
 type outfiles
 val delete_temps : outfiles -> unit 
 
-type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Thread | `Optimize | `Bytecode] list
+type options = [`Verbose | `Shared | `ForPack of string | `Include of string | `Package of string | `Dontlink of string | `Linkpkg | `Debug | `Thread | `Optimize | `Bytecode] list
 
 val compile_module :
   ?options:options ->

--- a/src/malfunction_main.ml
+++ b/src/malfunction_main.ml
@@ -72,6 +72,7 @@ let parse_args args =
     | "-o" :: o :: rest -> output := Some o; parse_opts mode rest
     | "-shared" :: rest -> opts := `Shared :: !opts; parse_opts mode rest
     | "-for-pack" :: o :: rest -> opts := `ForPack o :: !opts; parse_opts mode rest
+    | "-I" :: s :: rest -> opts := `Include s :: !opts; parse_opts mode rest
     | "-package" :: s :: rest -> opts := `Package s :: !opts; parse_opts mode rest
     | "-dontlink" :: s :: rest -> 
       if mode = `Compile then (opts := `Dontlink s :: !opts; parse_opts mode rest)

--- a/src/malfunction_main.ml
+++ b/src/malfunction_main.ml
@@ -80,6 +80,7 @@ let parse_args args =
     | "-linkpkg" :: rest -> 
       if mode = `Compile then (opts := `Linkpkg :: !opts; parse_opts mode rest)
       else usage ()
+    | "-g" :: rest -> opts := `Debug :: !opts; parse_opts mode rest
     | "-thread" :: rest -> 
         if mode = `Compile then (opts := `Thread :: !opts; parse_opts mode rest)
         else usage ()


### PR DESCRIPTION
We extend the list of supported flags, following the OCaml convention. The two new flags are -I and -g.